### PR TITLE
Change API to return empty array instead of false

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 // Dependencies
-var _ = require('lodash');
 var findRoot = require('find-root');
 var fs = require('fs');
 var path = require('path');
@@ -8,102 +7,47 @@ var root = findRoot(process.cwd());
 // Methods
 
 var find = function() {
-  // Define the export array
-  var packs = [];
-  var dependencies = getDependencies();
-
-  if (!dependencies) {
-    return false;
-  }
-
-  _.forEach(dependencies, function(pkg) {
-    if (isSeedPack(pkg)) {
-      // Push to packs if is seed-pack
-      packs.push(pkg);
-    }
+  return getDependencies().filter(function(pkg) {
+    return isSeedPack(pkg);
   });
-
-  if (packs.length) {
-    return packs;
-  }
-  else {
-    return false;
-  }
 };
 
 var findPaths = function() {
-  var packs = find();
-  var paths = [];
-
-  if (!packs) {
-    return false;
-  }
-
-  _.forEach(packs, function(pack) {
-    paths.push(require(pack));
-  });
-
-  return packs;
+  return find().map(require);
 };
 
 
 var isSeedPack = function(pkg) {
-  var keywords = getKeywords(pkg);
-  if (keywords) {
-    return _.includes(keywords, 'seed-pack');
-  }
-  else {
-    return false;
-  }
+  return getKeywords(pkg).indexOf('seed-pack') !== -1;
 };
 
 
 var getDependencies = function() {
   var pkg = require(path.join(root, 'package.json'));
-  var devDeps = pkg.devDependencies;
-  var deps = pkg.dependencies;
-  var dependencies = [];
+  var devDeps = pkg.devDependencies || {};
+  var deps = pkg.dependencies || {};
 
-  if (devDeps) {
-    _.forEach(_.keys(devDeps), function(pkg) {
-      dependencies.push(pkg);
-    });
-  }
-
-  if (deps) {
-    _.forEach(_.keys(deps), function(pkg) {
-      dependencies.push(pkg);
-    });
-  }
-
-  if (dependencies.length) {
-    return dependencies;
-  }
-  else {
-    return false;
-  }
+  return Object.keys(devDeps).concat(Object.keys(deps));
 };
 
 
 var getKeywords = function(pkg) {
-  var _path = path.join(root, 'node_modules', pkg, 'package.json');
-  var stat = fs.statSync(_path).isFile();
+  var packageJSON = path.join(root, 'node_modules', pkg, 'package.json');
+  var stat = fs.statSync(packageJSON).isFile();
 
   if (!stat) {
     console.log(pkg + ' could not be found in node_modules.');
     console.log('Running npm install might help!');
     return process.exit(1);
   }
-  else {
-    var module = require(_path);
-    var keywords = module.keywords;
-    if (keywords) {
-      return keywords;
-    }
-    else {
-      return false;
-    }
+
+  var keywords = require(packageJSON).keywords;
+
+  if (!keywords || !keywords.length) {
+    return [];
   }
+
+  return keywords;
 };
 
 

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "node": ">=4"
   },
   "dependencies": {
-    "find-root": "^1.0.0",
-    "lodash": "^4.14.0"
+    "find-root": "^1.0.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/test/find.js
+++ b/test/find.js
@@ -1,18 +1,12 @@
 // Test :: Find
-var _ = require('lodash');
 var assert = require('chai').assert;
 var packfinder = require('../index');
 
 var packs = packfinder.find();
 
 describe('packfinder: find', function() {
-  var pack = packs[0];
-
   it('should automatically include seed packs (from package.json)', function() {
-    assert.equal(true, pack.includes('seed-breakpoints'));
-  });
-
-  it('should include not seed pack dependencies', function() {
-    assert.equal(false, pack.includes('seed-props'));
+    assert.equal(packs.length, 1);
+    assert.equal(packs[0], 'seed-breakpoints');
   });
 });

--- a/test/findPaths.js
+++ b/test/findPaths.js
@@ -1,20 +1,21 @@
 // Test :: Find Paths
 
-var _ = require('lodash');
 var assert = require('chai').assert;
 var packfinder = require('../index');
 
 var packs = packfinder.findPaths();
 
 describe('packfinder: findPaths', function() {
-  var pack = packs[0];
-
   it('should automatically include seed packs (from package.json)', function() {
-    assert.equal(true, pack.includes('seed-breakpoints'));
+    assert.ok(packs.some(function(pack) {
+      return /seed-breakpoints/.test(pack);
+    }));
   });
 
   it('should include seed pack dependencies', function() {
-    assert.equal(false, pack.includes('seed-props'));
+    assert.ok(packs.some(function(pack) {
+      return /seed-props/.test(pack);
+    }));
   });
 });
 


### PR DESCRIPTION
Returning false sometimes and an array at other times makes consuming
this package more complex. So prefer an empty array instead of false.

Fixes #1.

Tests are changed for clarity, and one of them wasn't working. I believe
that (aside from the intended API change in the empty cases), everything
should work as it did before.

Also accidentally refactored everything lots:
- Prefer map and filter over _.forEach and push
- Prefer indexOf over _.includes (for now)
- Use Object.keys instead of _.keys
- ...and therefore remove lodash dependency
